### PR TITLE
Update dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Links to the embeddings (#dimensions=300, #vectors=855380):
 
 #### Embeddings
 Links to the embeddings (#dimensions=300, #vectors=985667): 
-- [Vector format (.vec)](https://s3-us-west-1.amazonaws.com/fasttext-vectors/wiki.es.vec) (2.4 GB) 
-- [Binary plus vector format (.zip)](https://s3-us-west-1.amazonaws.com/fasttext-vectors/wiki.es.zip) (5.4 GB)
+- [Vector format (.vec)](https://dl.fbaipublicfiles.com/fasttext/vectors-wiki/wiki.es.vec) (2.4 GB) 
+- [Binary plus vector format (.zip)](https://dl.fbaipublicfiles.com/fasttext/vectors-wiki/wiki.es.zip) (5.4 GB)
 
 #### Algorithm
 - Implementation: [FastText](https://github.com/facebookresearch/fastText) with Skipgram
@@ -81,5 +81,5 @@ Links to the embeddings (#dimensions=300, #vectors=1000653)
 - FastText embeddings from SBWC: Word embeddings were computed by [Jorge Pérez](https://github.com/jorgeperezrojas). You can use these vectors as you wish under the CC-BY-4.0 license. You may also want to cite the FastText paper [Enriching Word Vectors with Subword Information](https://arxiv.org/abs/1607.04606) and the [Spanish Billion Word Corpus project](http://crscardellino.github.io/SBWCE/). 
 - GloVe embeddings from SBWC: Word embeddings were computed by [Jorge Pérez](https://github.com/jorgeperezrojas). You can use these vectors as you wish under the CC-BY-4.0 license. You may also want to cite the GloVe paper [GloVe: Global Vectors for Word Representation](https://nlp.stanford.edu/pubs/glove.pdf) and the [Spanish Billion Word Corpus project](http://crscardellino.github.io/SBWCE/).
 - FastText embeddings from Spanish Wikipedia: Word embeddings were computed by [FastText team](https://github.com/facebookresearch/fastText).
-Please refer to [FastText Pre-trained Vectors page](https://github.com/facebookresearch/fastText/blob/master/pretrained-vectors.md) if you want to use these vectors.
+Please refer to [FastText Pre-trained Vectors page](https://github.com/facebookresearch/fastText/blob/master/docs/pretrained-vectors.md) if you want to use these vectors.
 - Word2Vec embeddings from SBWC: Word embeddings were computed by [Cristian Cardellino](https://github.com/crscardellino). Please refer to the [SBWCE page](http://crscardellino.github.io/SBWCE/) if you want to use these vectors.


### PR DESCRIPTION
FB has changed the link for their pretrained vectors.
The source of the new links are in the [updated version of their docs](https://github.com/facebookresearch/fastText/blob/master/docs/pretrained-vectors.md)